### PR TITLE
Fix armsize typo in example

### DIFF
--- a/_posts/2021/2021-03-14-dinosaur-logic-program.md
+++ b/_posts/2021/2021-03-14-dinosaur-logic-program.md
@@ -106,7 +106,7 @@ living(maria).
 % This tells use size of arms for each living thing
 armsize(vanessa, "small").
 armsize(fernando, "large").
-armsize(fernando, "small").
+armsize(maria, "small").
 
 % A boolean to say we can roar!
 canroar(vanessa).


### PR DESCRIPTION
Fix a duplicate in the example in what I assume was a cut-and-paste, with the admittedly somewhat speculative assumption that the answer set for armsize(maria) is also “small”.